### PR TITLE
CENG-437: Add the ability to auth via oidc only

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -69,3 +69,44 @@ jobs:
             Write-Output "Config file not found at $configFile"
           }
         shell: pwsh
+
+  test-oidc-only:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: "Set up Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          
+      - name: "Install dependencies"
+        run: npm install
+        
+      - name: "Build project"
+        run: npm run build
+      
+      - name: OIDC Authentication Only
+        uses: ./
+        with:
+          oidc-namespace: ${{ vars.NAMESPACE }}
+          oidc-service-slug: ${{ vars.SERVICE_ACCOUNT }}
+          oidc-auth-only: 'true'
+      
+      - name: Test Authentication
+        run: |
+          curl -X GET \
+            -H "Authorization: Bearer $CLOUDSMITH_API_KEY" \
+            https://api.cloudsmith.io/v1/user/self/ \
+            | jq -r '.authenticated'
+
+      - name: Test CLI Installation should fail
+        id: cli-test
+        continue-on-error: true
+        run: cloudsmith --version
+        
+      - name: Verify CLI installation failed
+        if: steps.cli-test.outcome == 'success'
+        run: |
+          echo "CLI installation should have failed but succeeded"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This GitHub Action installs the Cloudsmith CLI and pre-authenticates it using OI
 - [`api-key`](action.yml): API Key for Cloudsmith (optional). 🔑
 - [`oidc-namespace`](action.yml): Cloudsmith organisation/namespace for OIDC (optional). 🌐
 - [`oidc-service-slug`](action.yml): Cloudsmith service account slug for OIDC (optional). 🐌
+- [`oidc-auth-only`](action.yml): Only perform OIDC authentication without installing the CLI (optional, default: false). 🔐
 - [`pip-install`](action.yml): Install the Cloudsmith CLI via pip (optional). 🐍
 - [`executable-path`](action.yml): Path to the Cloudsmith CLI executable (optional, default: `GITHUB_WORKSPACE/bin/`). 🛠️
 
@@ -25,7 +26,7 @@ This GitHub Action installs the Cloudsmith CLI and pre-authenticates it using OI
 Cloudsmith OIDC [documentation](https://help.cloudsmith.io/docs/openid-connect) 📚
 
 ```yaml
-uses: cloudsmith-io/cloudsmith-cli-action@v1.0.1
+uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
 with:
   oidc-namespace: 'your-oidc-namespace'
   oidc-service-slug: 'your-service-account-slug'
@@ -36,10 +37,27 @@ with:
 Personal API Key can be found [here](https://cloudsmith.io/user/settings/api/), for CI-CD deployments we recommend using [Service Accounts](https://help.cloudsmith.io/docs/service-accounts). 🔒
 
 ```yaml
-uses: cloudsmith-io/cloudsmith-cli-action@v1.0.1
+uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
 with:
   api-key: 'your-api-key'
 ```
+
+## Example Usage with OIDC Authentication Only
+
+If you only need to authenticate with Cloudsmith's API without installing the CLI:
+
+```yaml
+uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
+with:
+  oidc-namespace: 'your-oidc-namespace'
+  oidc-service-slug: 'your-service-account-slug'
+  oidc-auth-only: 'true'
+```
+
+This will:
+- Perform OIDC authentication
+- Set the OIDC token as `CLOUDSMITH_API_KEY` environment variable
+- Skip CLI installation
 
 ## Cloudsmith CLI Commands
 
@@ -68,7 +86,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cloudsmith CLI
-        uses: cloudsmith-io/cloudsmith-cli-action@v1.0.1
+        uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
         with:
           oidc-namespace: 'your-oidc-namespace'
           oidc-service-slug: 'your-service-account-slug'
@@ -77,7 +95,6 @@ jobs:
         run: |
           cloudsmith push python your-namespace/your-repository dist/*.tar.gz
 ```
-
 ## Contribution
 
 Please check our [CONTRIBUTION](CONTRIBUTION.md) doc for more information. 🤝
@@ -89,3 +106,4 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ## Support
 
 If you have any questions or need further assistance, please open an issue on GitHub. We're here to help! 💬 Alternatively, you can contact us at [support.cloudsmith.com](https://support.cloudsmith.com/).
+

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Cloudsmith service account slug for OIDC'
     default: ''
     required: false
+  oidc-auth-only:
+    description: 'Only perform OIDC authentication without installing the CLI'
+    default: 'false'
+    required: false
   pip-install:
     description: 'Install the Cloudsmith CLI via pip'
     default: 'false'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudsmith-github-action",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A GitHub Action to install Cloudsmith CLI and authenticate using OIDC",
   "main": "dist/index.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -31,8 +31,12 @@ async function run() {
       throw new Error("Either API key or OIDC inputs (namespace and service account slug) must be provided for authentication.");
     }
 
-    // Install the CLI
-    await installCli();
+    // Install the CLI only if oidc-auth-only is false
+    const oidcAuthOnly = core.getBooleanInput('oidc-auth-only');
+    if (!oidcAuthOnly) {
+      await installCli();
+    }
+  
   } catch (error) {
     core.setFailed(`Action failed: ${error.message}`);
   }


### PR DESCRIPTION
Add `oidc-auth-only` option for users that wish to only authenticate with Cloudsmith using OIDC for any 3rd party CLI's.