### PR TITLE
CENG-442: Add retry attempts when authenticating with OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ This GitHub Action installs the Cloudsmith CLI and pre-authenticates it using OI
 
 ## Inputs
 
-- [`cli-version`](action.yml): A specific version of the Cloudsmith CLI to install (optional). 📦
-- [`api-key`](action.yml): API Key for Cloudsmith (optional). 🔑
-- [`oidc-namespace`](action.yml): Cloudsmith organisation/namespace for OIDC (optional). 🌐
-- [`oidc-service-slug`](action.yml): Cloudsmith service account slug for OIDC (optional). 🐌
-- [`oidc-auth-only`](action.yml): Only perform OIDC authentication without installing the CLI (optional, default: false). 🔐
-- [`oidc-auth-retry`](action.yml): Number of retry attempts for OIDC authentication (0-10), 5 seconds delay between retries (optional, default: 3). 🔄
-- [`pip-install`](action.yml): Install the Cloudsmith CLI via pip (optional). 🐍
-- [`executable-path`](action.yml): Path to the Cloudsmith CLI executable (optional, default: `GITHUB_WORKSPACE/bin/`). 🛠️
+- `cli-version` (action.yml): A specific version of the Cloudsmith CLI to install (optional). 📦
+- `api-key` (action.yml): API Key for Cloudsmith (optional). 🔑
+- `oidc-namespace` (action.yml): Cloudsmith organisation/namespace for OIDC (optional). 🌐
+- `oidc-service-slug` (action.yml): Cloudsmith service account slug for OIDC (optional). 🐌
+- `oidc-auth-only` (action.yml): Only perform OIDC authentication without installing the CLI (optional, default: false). 🔐
+- `oidc-auth-retry` (action.yml): Number of retry attempts for OIDC authentication (0-10), 5 seconds delay between retries (optional, default: 3). 🔄
+- `pip-install` (action.yml): Install the Cloudsmith CLI via pip (optional). 🐍
+- `executable-path` (action.yml): Path to the Cloudsmith CLI executable (optional, default: `GITHUB_WORKSPACE/bin/`). 🛠️
 
 ## CLI Configuration Inputs ([documentation](https://github.com/cloudsmith-io/cloudsmith-cli?tab=readme-ov-file#non-credentials-configini))
 
-- [`api-host`](action.yml): API Host for Cloudsmith (optional). 🌐
-- [`api-proxy`](action.yml): API Proxy for Cloudsmith (optional). 🔗
-- [`api-ssl-verify`](action.yml): Verify SSL certificates for Cloudsmith API (optional). 🔒
-- [`api-user-agent`](action.yml): User Agent for Cloudsmith API (optional). 🕵️‍♂️
+- `api-host`: API Host for Cloudsmith (optional). 🌐
+- `api-proxy`: API Proxy for Cloudsmith (optional). 🔗
+- `api-ssl-verify`: Verify SSL certificates for Cloudsmith API (optional). 🔒
+- `api-user-agent`: User Agent for Cloudsmith API (optional). 🕵️‍♂️
 
 ## Example Usage with OIDC
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This GitHub Action installs the Cloudsmith CLI and pre-authenticates it using OI
 - [`oidc-namespace`](action.yml): Cloudsmith organisation/namespace for OIDC (optional). 🌐
 - [`oidc-service-slug`](action.yml): Cloudsmith service account slug for OIDC (optional). 🐌
 - [`oidc-auth-only`](action.yml): Only perform OIDC authentication without installing the CLI (optional, default: false). 🔐
+- [`oidc-auth-retry`](action.yml): Number of retry attempts for OIDC authentication (0-10), 5 seconds delay between retries (optional, default: 3). 🔄
 - [`pip-install`](action.yml): Install the Cloudsmith CLI via pip (optional). 🐍
 - [`executable-path`](action.yml): Path to the Cloudsmith CLI executable (optional, default: `GITHUB_WORKSPACE/bin/`). 🛠️
 
@@ -26,7 +27,7 @@ This GitHub Action installs the Cloudsmith CLI and pre-authenticates it using OI
 Cloudsmith OIDC [documentation](https://help.cloudsmith.io/docs/openid-connect) 📚
 
 ```yaml
-uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
+uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
 with:
   oidc-namespace: 'your-oidc-namespace'
   oidc-service-slug: 'your-service-account-slug'
@@ -37,7 +38,7 @@ with:
 Personal API Key can be found [here](https://cloudsmith.io/user/settings/api/), for CI-CD deployments we recommend using [Service Accounts](https://help.cloudsmith.io/docs/service-accounts). 🔒
 
 ```yaml
-uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
+uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
 with:
   api-key: 'your-api-key'
 ```
@@ -47,7 +48,7 @@ with:
 If you only need to authenticate with Cloudsmith's API without installing the CLI:
 
 ```yaml
-uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
+uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
 with:
   oidc-namespace: 'your-oidc-namespace'
   oidc-service-slug: 'your-service-account-slug'
@@ -86,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cloudsmith CLI
-        uses: cloudsmith-io/cloudsmith-cli-action@v1.0.2
+        uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
         with:
           oidc-namespace: 'your-oidc-namespace'
           oidc-service-slug: 'your-service-account-slug'

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Only perform OIDC authentication without installing the CLI'
     default: 'false'
     required: false
+  oidc-auth-retry:
+    description: 'Number of retry attempts for OIDC authentication (0-10)'
+    default: '3'
+    required: false
   pip-install:
     description: 'Install the Cloudsmith CLI via pip'
     default: 'false'

--- a/dist/index.js
+++ b/dist/index.js
@@ -33431,6 +33431,23 @@ const axios = __nccwpck_require__(8757);
 const core = __nccwpck_require__(2186);
 
 const DEFAULT_API_HOST = 'api.cloudsmith.io';
+const RETRY_DELAY_MS = 5000; // 5 seconds delay between attempts
+
+async function retryWithDelay(fn, retries) {
+  let lastError;
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        core.info(`OIDC authentication attempt ${attempt} failed, retrying in ${RETRY_DELAY_MS/1000} seconds...`);
+        await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+      }
+    }
+  }
+  throw lastError;
+}
 
 /**
  * Authenticates with Cloudsmith using OIDC and validates the token.
@@ -33438,45 +33455,50 @@ const DEFAULT_API_HOST = 'api.cloudsmith.io';
  * @param {string} orgName - The organization name.
  * @param {string} serviceAccountSlug - The service account slug.
  * @param {string} apiHost - The API host to connect to (optional).
+ * @param {number} retryAttempts - Number of retry attempts for authentication (0-10).
  */
-async function authenticate(orgName, serviceAccountSlug, apiHost) {
+async function authenticate(orgName, serviceAccountSlug, apiHost, retryAttempts = 3) {
   try {
-    // Retrieve the OIDC ID token from GitHub Actions
-    const idToken = await core.getIDToken("api://AzureADTokenExchange");
+    core.info(`Attempting OIDC authentication with ${retryAttempts} retry attempts...`);
 
-    // Use the provided apiHost or default to api.cloudsmith.io
-    const baseUrl = `https://${apiHost || DEFAULT_API_HOST}`;
+    await retryWithDelay(async () => {
+      // Retrieve the OIDC ID token from GitHub Actions
+      const idToken = await core.getIDToken("api://AzureADTokenExchange");
 
-    // Send a POST request to Cloudsmith API to authenticate using the OIDC token
-    const response = await axios.post(
-      `${baseUrl}/openid/${orgName}/`,
-      {
-        oidc_token: idToken,
-        service_slug: serviceAccountSlug,
-      },
-      {
-        headers: {
-          "Content-Type": "application/json",
+      // Use the provided apiHost or default to api.cloudsmith.io
+      const baseUrl = `https://${apiHost || DEFAULT_API_HOST}`;
+
+      // Send a POST request to Cloudsmith API to authenticate using the OIDC token
+      const response = await axios.post(
+        `${baseUrl}/openid/${orgName}/`,
+        {
+          oidc_token: idToken,
+          service_slug: serviceAccountSlug,
         },
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      // Check if the authentication was successful
+      if (response.status !== 200 && response.status !== 201) {
+        throw new Error(`Failed to authenticate: ${response.statusText}`);
       }
-    );
 
-    // Check if the authentication was successful
-    if (response.status !== 200 && response.status !== 201) {
-      throw new Error(`Failed to authenticate: ${response.statusText}`);
-    }
+      // Extract the API token from the response
+      const token = response.data.token;
 
-    // Extract the API token from the response
-    const token = response.data.token;
+      // Export the API token as an environment variable
+      core.exportVariable("CLOUDSMITH_API_KEY", token);
+      core.info(
+        "Authenticated successfully with OIDC and saved JWT (token) to `CLOUDSMITH_API_KEY` environment variable."
+      );
 
-    // Export the API token as an environment variable
-    core.exportVariable("CLOUDSMITH_API_KEY", token);
-    core.info(
-      "Authenticated successfully with OIDC and saved JWT (token) to `CLOUDSMITH_API_KEY` environment variable."
-    );
-
-    // Validate the token to ensure it is correct
-    await validateToken(token, baseUrl);
+      // Validate the token to ensure it is correct
+      await validateToken(token, baseUrl);
+    }, retryAttempts);
   } catch (error) {
     // Set the GitHub Action as failed if any error occurs
     core.setFailed(`OIDC authentication failed: ${error.message}`);
@@ -43051,6 +43073,7 @@ async function run() {
     const orgName = core.getInput('oidc-namespace');
     const serviceAccountSlug = core.getInput('oidc-service-slug');
     const apiKey = core.getInput('api-key');
+    const oidcAuthRetry = Math.min(Math.max(parseInt(core.getInput('oidc-auth-retry') || '3', 10), 0), 10);
     
     // Cloudsmith CLI optional inputs
     const apiHost = core.getInput('api-host');
@@ -43068,7 +43091,7 @@ async function run() {
       core.exportVariable("CLOUDSMITH_API_KEY", apiKey);
       core.info("Using provided API key for authentication.");
     } else if (orgName && serviceAccountSlug) {
-      await oidcAuth.authenticate(orgName, serviceAccountSlug, apiHost);
+      await oidcAuth.authenticate(orgName, serviceAccountSlug, apiHost, oidcAuthRetry);
     } else {
       throw new Error("Either API key or OIDC inputs (namespace and service account slug) must be provided for authentication.");
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudsmith-github-action",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A GitHub Action to install Cloudsmith CLI and authenticate using OIDC",
   "main": "dist/index.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ async function run() {
     const orgName = core.getInput('oidc-namespace');
     const serviceAccountSlug = core.getInput('oidc-service-slug');
     const apiKey = core.getInput('api-key');
+    const oidcAuthRetry = Math.min(Math.max(parseInt(core.getInput('oidc-auth-retry') || '3', 10), 0), 10);
     
     // Cloudsmith CLI optional inputs
     const apiHost = core.getInput('api-host');
@@ -26,7 +27,7 @@ async function run() {
       core.exportVariable("CLOUDSMITH_API_KEY", apiKey);
       core.info("Using provided API key for authentication.");
     } else if (orgName && serviceAccountSlug) {
-      await oidcAuth.authenticate(orgName, serviceAccountSlug, apiHost);
+      await oidcAuth.authenticate(orgName, serviceAccountSlug, apiHost, oidcAuthRetry);
     } else {
       throw new Error("Either API key or OIDC inputs (namespace and service account slug) must be provided for authentication.");
     }

--- a/src/oidc-auth.js
+++ b/src/oidc-auth.js
@@ -2,6 +2,23 @@ const axios = require("axios");
 const core = require("@actions/core");
 
 const DEFAULT_API_HOST = 'api.cloudsmith.io';
+const RETRY_DELAY_MS = 5000; // 5 seconds delay between attempts
+
+async function retryWithDelay(fn, retries) {
+  let lastError;
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        core.info(`OIDC authentication attempt ${attempt} failed, retrying in ${RETRY_DELAY_MS/1000} seconds...`);
+        await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+      }
+    }
+  }
+  throw lastError;
+}
 
 /**
  * Authenticates with Cloudsmith using OIDC and validates the token.
@@ -9,45 +26,50 @@ const DEFAULT_API_HOST = 'api.cloudsmith.io';
  * @param {string} orgName - The organization name.
  * @param {string} serviceAccountSlug - The service account slug.
  * @param {string} apiHost - The API host to connect to (optional).
+ * @param {number} retryAttempts - Number of retry attempts for authentication (0-10).
  */
-async function authenticate(orgName, serviceAccountSlug, apiHost) {
+async function authenticate(orgName, serviceAccountSlug, apiHost, retryAttempts = 3) {
   try {
-    // Retrieve the OIDC ID token from GitHub Actions
-    const idToken = await core.getIDToken("api://AzureADTokenExchange");
+    core.info(`Attempting OIDC authentication with ${retryAttempts} retry attempts...`);
 
-    // Use the provided apiHost or default to api.cloudsmith.io
-    const baseUrl = `https://${apiHost || DEFAULT_API_HOST}`;
+    await retryWithDelay(async () => {
+      // Retrieve the OIDC ID token from GitHub Actions
+      const idToken = await core.getIDToken("api://AzureADTokenExchange");
 
-    // Send a POST request to Cloudsmith API to authenticate using the OIDC token
-    const response = await axios.post(
-      `${baseUrl}/openid/${orgName}/`,
-      {
-        oidc_token: idToken,
-        service_slug: serviceAccountSlug,
-      },
-      {
-        headers: {
-          "Content-Type": "application/json",
+      // Use the provided apiHost or default to api.cloudsmith.io
+      const baseUrl = `https://${apiHost || DEFAULT_API_HOST}`;
+
+      // Send a POST request to Cloudsmith API to authenticate using the OIDC token
+      const response = await axios.post(
+        `${baseUrl}/openid/${orgName}/`,
+        {
+          oidc_token: idToken,
+          service_slug: serviceAccountSlug,
         },
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      // Check if the authentication was successful
+      if (response.status !== 200 && response.status !== 201) {
+        throw new Error(`Failed to authenticate: ${response.statusText}`);
       }
-    );
 
-    // Check if the authentication was successful
-    if (response.status !== 200 && response.status !== 201) {
-      throw new Error(`Failed to authenticate: ${response.statusText}`);
-    }
+      // Extract the API token from the response
+      const token = response.data.token;
 
-    // Extract the API token from the response
-    const token = response.data.token;
+      // Export the API token as an environment variable
+      core.exportVariable("CLOUDSMITH_API_KEY", token);
+      core.info(
+        "Authenticated successfully with OIDC and saved JWT (token) to `CLOUDSMITH_API_KEY` environment variable."
+      );
 
-    // Export the API token as an environment variable
-    core.exportVariable("CLOUDSMITH_API_KEY", token);
-    core.info(
-      "Authenticated successfully with OIDC and saved JWT (token) to `CLOUDSMITH_API_KEY` environment variable."
-    );
-
-    // Validate the token to ensure it is correct
-    await validateToken(token, baseUrl);
+      // Validate the token to ensure it is correct
+      await validateToken(token, baseUrl);
+    }, retryAttempts);
   } catch (error) {
     // Set the GitHub Action as failed if any error occurs
     core.setFailed(`OIDC authentication failed: ${error.message}`);


### PR DESCRIPTION
# OIDC Authentication Retry Mechanism

This PR adds a retry mechanism for OIDC authentication to improve reliability when temporary network issues or service availability hiccups occur.

## Changes

- Added new input parameter `oidc-auth-retry` (default: 3, range: 0-10)
- Implemented retry logic with 5-second delay between attempts
- Updated documentation to reflect the new feature
