### PR TITLE
fix: Set oidc-token output in OIDC authentication

### DIFF
--- a/src/oidc-auth.js
+++ b/src/oidc-auth.js
@@ -63,6 +63,8 @@ async function authenticate(orgName, serviceAccountSlug, apiHost, retryAttempts 
 
       // Export the API token as an environment variable
       core.exportVariable("CLOUDSMITH_API_KEY", token);
+      // Set the token as an output
+      core.setOutput('oidc-token', token);
       core.info(
         "Authenticated successfully with OIDC and saved JWT (token) to `CLOUDSMITH_API_KEY` environment variable."
       );


### PR DESCRIPTION
Adds missing core.setOutput('oidc-token', token) call to make the oidc-token output defined in action.yml actually available to consumers.

Fixes issue #6