### PR TITLE
style: add white space after download url in error message

### DIFF
--- a/src/download-cli.js
+++ b/src/download-cli.js
@@ -23,7 +23,7 @@ fs.mkdirSync(path.dirname(EXECUTABLE_PATH), { recursive: true });
 async function downloadFile(url, dest) {
   const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+    throw new Error(`Failed to fetch ${url} : ${res.statusText}`);
   }
   const fileStream = fs.createWriteStream(dest);
   await pipeline(Readable.fromWeb(res.body), fileStream);


### PR DESCRIPTION
This is a very simple cosmetic change to fix a formatting issue with the download URL that shows up in error messages.

Below was an error message received during a failed download of a specific version of the CLI:

>Error: Failed to download the specific release: Failed to fetch [https://dl.cloudsmith.io/public/cloudsmith/cli-zipapp/raw/names/cloudsmith-cli/versions/1.11.1/cloudsmith.pyz:](https://dl.cloudsmith.io/public/cloudsmith/cli-zipapp/raw/names/cloudsmith-cli/versions/1.11.1/cloudsmith.pyz:) Not Found


When this error occurs and you click the link, the colon character comes with it, this change removes the colon char from the auto detected link.