### PR TITLE
chore(ENG-12048): v1 Deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [1.0.11] - 2026-05-04
+
+### Deprecated
+
+- **`@v1` is deprecated.** v1 runs on Node.js 20, which reached [end-of-life on 2026-04-30](https://nodejs.org/en/about/previous-releases). Please migrate to [`@v2`](https://github.com/cloudsmith-io/cloudsmith-cli-action/tree/master#readme), which runs on Node.js 24.
+- **Security-only patches** for `@v1` will continue until **2026-12-31**. No new features or non-security fixes will land on `@v1` after that date.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 
 This GitHub Action installs the Cloudsmith CLI and pre-authenticates it using OIDC or API Key. 🚀
 
+> **🛑 DEPRECATED — `@v1` is end-of-life.**
+>
+> `@v1` runs on Node.js 20, which reached [end-of-life on 2026-04-30](https://nodejs.org/en/about/previous-releases). Please migrate to [`@v2`](https://github.com/cloudsmith-io/cloudsmith-cli-action/tree/master#readme), which runs on Node.js 24.
+>
+> - **Migration guide:** see the [v2 README](https://github.com/cloudsmith-io/cloudsmith-cli-action/tree/master#readme) for breaking changes (Node.js 24 runtime, OIDC audience default).
+> - **Security-only patches** for `@v1` will continue until **2026-12-31**. No new features or non-security fixes will land on `@v1` after that date.
+> - To migrate, change `cloudsmith-io/cloudsmith-cli-action@v1` → `cloudsmith-io/cloudsmith-cli-action@v2` in your workflows.
+
 > **⚠️ Notice:** If you are running on self-hosted runners, Python version 3.9 or higher is required. Please ensure your runner meets this requirement to avoid any issues. We recommend using [setup-python](https://github.com/actions/setup-python) action for installing Python. 🐍
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Cloudsmith CLI Setup
-description: Set up Cloudsmith CLI in GitHub Actions
+description: '[DEPRECATED — please migrate to @v2 (Node.js 24). v1 runs on Node.js 20 (EoL 2026-04-30); security-only patches until 2026-12-31.] Set up Cloudsmith CLI in GitHub Actions'
 author: BartoszBlizniak
 inputs:
   cli-version:

--- a/dist/index.js
+++ b/dist/index.js
@@ -35615,7 +35615,7 @@ fs.mkdirSync(path.dirname(EXECUTABLE_PATH), { recursive: true });
 async function downloadFile(url, dest) {
   const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+    throw new Error(`Failed to fetch ${url} : ${res.statusText}`);
   }
   const fileStream = fs.createWriteStream(dest);
   await new Promise((resolve, reject) => {
@@ -45703,6 +45703,12 @@ const { createConfigFile } = __nccwpck_require__(3145);
 
 async function run() {
   try {
+    core.warning(
+      "cloudsmith-cli-action @v1 is DEPRECATED. v1 runs on Node.js 20, which reached end-of-life on 2026-04-30 (https://nodejs.org/en/about/previous-releases). " +
+        "Please migrate to @v2, which runs on Node.js 24. Security-only patches for v1 will continue until 2026-12-31. " +
+        "Migration guide: https://github.com/cloudsmith-io/cloudsmith-cli-action#readme",
+    );
+
     // Get inputs from GitHub Actions workflow
     const orgName = core.getInput("oidc-namespace");
     const serviceAccountSlug = core.getInput("oidc-service-slug");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudsmith-github-action",
-  "version": "1.0.3",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudsmith-github-action",
-      "version": "1.0.3",
+      "version": "1.0.11",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/exec": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudsmith-github-action",
-  "version": "1.0.3",
+  "version": "1.0.11",
   "description": "A GitHub Action to install Cloudsmith CLI and authenticate using OIDC",
   "main": "dist/index.js",
   "scripts": {

--- a/src/download-cli.js
+++ b/src/download-cli.js
@@ -22,7 +22,7 @@ fs.mkdirSync(path.dirname(EXECUTABLE_PATH), { recursive: true });
 async function downloadFile(url, dest) {
   const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+    throw new Error(`Failed to fetch ${url} : ${res.statusText}`);
   }
   const fileStream = fs.createWriteStream(dest);
   await new Promise((resolve, reject) => {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,12 @@ const { createConfigFile } = require("./create-config-file");
 
 async function run() {
   try {
+    core.warning(
+      "cloudsmith-cli-action @v1 is DEPRECATED. v1 runs on Node.js 20, which reached end-of-life on 2026-04-30 (https://nodejs.org/en/about/previous-releases). " +
+        "Please migrate to @v2, which runs on Node.js 24. Security-only patches for v1 will continue until 2026-12-31. " +
+        "Migration guide: https://github.com/cloudsmith-io/cloudsmith-cli-action#readme",
+    );
+
     // Get inputs from GitHub Actions workflow
     const orgName = core.getInput("oidc-namespace");
     const serviceAccountSlug = core.getInput("oidc-service-slug");


### PR DESCRIPTION
## Summary

  Following the Node.js release cycle, [Node 20 is now EoL](https://nodejs.org/en/about/previous-releases#:~:text=Mar%2024%2C%202026-,EOL,-Details) — this change adds deprecation notices to `@v1`. We will continue to provide **security updates until end of 2026** to allow time for migration.

  ## Migrating from `@v1` → `@v2`

  ### 1. Bump the action reference

  ```diff
  - uses: cloudsmith-io/cloudsmith-cli-action@v1
  + uses: cloudsmith-io/cloudsmith-cli-action@v2
  ```

  ### 2. OIDC audience default has changed

  `@v2` now defaults `oidc-audience` to `https://github.com/{org-name}` (resolved from
  `GITHUB_REPOSITORY_OWNER`) instead of `api://AzureADTokenExchange`.

  If your downstream validates the `aud` claim against the old value, either update that validation **or** pin
  the previous default explicitly:

  ```yaml
  with:
    oidc-audience: 'api://AzureADTokenExchange'
  ```

  ### 3. Self-hosted runners need Node.js 24

  GitHub-hosted runners are unaffected. Self-hosted runners must provide Node.js 24+.

  No input or output names changed — existing workflows otherwise migrate one-for-one.