### PR TITLE
Register OIDC token as a secret before exposing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ---
+### Security
+
+- Mask the OIDC-issued Cloudsmith API token as a secret so it is replaced with `***` in any subsequent workflow log line. The token was previously exported via `core.exportVariable("CLOUDSMITH_API_KEY", token)` and `core.setOutput('oidc-token', token)` without first calling `core.setSecret(token)`, so a downstream step that printed `$CLOUDSMITH_API_KEY` (e.g. via `set -x` or accidental `echo`) would leak the bearer token in clear text.
 
 ## [2.0.1] - 2025-12-23
 ---

--- a/dist/index.js
+++ b/dist/index.js
@@ -25735,7 +25735,7 @@ fs.mkdirSync(path.dirname(EXECUTABLE_PATH), { recursive: true });
 async function downloadFile(url, dest) {
   const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+    throw new Error(`Failed to fetch ${url} : ${res.statusText}`);
   }
   const fileStream = fs.createWriteStream(dest);
   await pipeline(Readable.fromWeb(res.body), fileStream);
@@ -26058,6 +26058,12 @@ async function authenticate(
           error.response = response;
           throw error;
         }
+
+        // Register the token as a secret BEFORE exposing it via env var or
+        // step output, so any subsequent log line containing the literal
+        // token bytes is masked as `***`. Must precede `exportVariable` and
+        // `setOutput` so no intermediate log can leak the value.
+        core.setSecret(token);
 
         core.exportVariable("CLOUDSMITH_API_KEY", token);
         core.setOutput('oidc-token', token);

--- a/src/oidc-auth.js
+++ b/src/oidc-auth.js
@@ -243,6 +243,12 @@ async function authenticate(
           throw error;
         }
 
+        // Register the token as a secret BEFORE exposing it via env var or
+        // step output, so any subsequent log line containing the literal
+        // token bytes is masked as `***`. Must precede `exportVariable` and
+        // `setOutput` so no intermediate log can leak the value.
+        core.setSecret(token);
+
         core.exportVariable("CLOUDSMITH_API_KEY", token);
         core.setOutput('oidc-token', token);
         core.info(

--- a/src/oidc-auth.js
+++ b/src/oidc-auth.js
@@ -245,7 +245,7 @@ async function authenticate(
 
         // Register the token as a secret BEFORE exposing it via env var or
         // step output, so any subsequent log line containing the literal
-        // token bytes is masked as `***`. Must precede `exportVariable` and
+        // token value is masked as `***`. Must precede `exportVariable` and
         // `setOutput` so no intermediate log can leak the value.
         core.setSecret(token);
 


### PR DESCRIPTION
## Summary

`core.exportVariable("CLOUDSMITH_API_KEY", token)` and `core.setOutput('oidc-token', token)` do not register the value as a secret with the runner, so the OIDC-issued Cloudsmith API token remains unmasked in workflow logs. Any downstream step that prints `$CLOUDSMITH_API_KEY` — intentionally, via `set -x`, or via debug-mode logging in another action — leaks the bearer token in clear text. The token is short-lived (~2h by default) but valid against the Cloudsmith API for the rest of its TTL, so the leak window is real.

This PR adds a single `core.setSecret(token)` call **before** the token is exported anywhere, so the runner registers the literal token bytes as a secret and replaces them with `***` in all subsequent log lines — including the value rendered through the `oidc-token` step output (since `setSecret` masks by value, not by name).

## Why ordering matters

`core.setSecret` emits the `::add-mask::<value>` workflow command immediately. Once that command has been processed by the runner, every future log line containing those bytes is redacted. If `setSecret` were called *after* `exportVariable` / `setOutput` / `core.info`, an unfortunate intermediate log line could still leak the raw value. Calling `setSecret` first closes that window.

The same pattern is already used internally by `@actions/core` itself for the GitHub OIDC ID token (`setSecret(id_token)` is called before that token is ever read).

## Reference

Every other auth action in the GitHub Actions ecosystem uses this pattern, e.g. [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials), [`google-github-actions/auth`](https://github.com/google-github-actions/auth), [`azure/login`](https://github.com/Azure/login) — all call `core.setSecret` on any bearer token they expose.

## Test plan

- [ ] Run a workflow that uses `oidc-auth-only: 'true'` and adds an explicit `run: echo "$CLOUDSMITH_API_KEY"` after `Cloudsmith CLI Setup`. The echoed value should render as `***` instead of the JWT.
- [ ] Run a workflow that uses `oidc-auth-only: 'true'` and references `${{ steps.<id>.outputs.oidc-token }}` in a later step. The rendered output should also render as `***`.
- [ ] Existing test workflows continue to pass (`pip-install`, default install, API-key auth path).

Made with [Cursor](https://cursor.com)