### PR TITLE
feat: export CLI-resolved authentication token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,10 +264,22 @@ jobs:
           persist-credentials: false
 
       - name: Install and authenticate
+        id: setup
         uses: ./
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          export-auth-token: "true"
           verify-auth: "true"
+
+      - name: Check exported token
+        shell: bash
+        env:
+          EXPECTED_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          OUTPUT_TOKEN: ${{ steps.setup.outputs.oidc-token }}
+        run: |
+          set -euo pipefail
+          test "$CLOUDSMITH_API_KEY" = "$EXPECTED_API_KEY"
+          test "$OUTPUT_TOKEN" = "$EXPECTED_API_KEY"
 
       - name: whoami from PATH
         shell: bash
@@ -295,11 +307,22 @@ jobs:
           persist-credentials: false
 
       - name: Install and authenticate
+        id: setup
         uses: ./
         with:
           oidc-namespace: ${{ vars.CLOUDSMITH_NAMESPACE }}
           oidc-service-slug: ${{ vars.CLOUDSMITH_SERVICE_SLUG }}
+          export-auth-token: "true"
           verify-auth: "true"
+
+      - name: Check exported token
+        shell: bash
+        env:
+          OUTPUT_TOKEN: ${{ steps.setup.outputs.oidc-token }}
+        run: |
+          set -euo pipefail
+          test -n "$OUTPUT_TOKEN"
+          test "$CLOUDSMITH_API_KEY" = "$OUTPUT_TOKEN"
 
       - name: whoami from PATH
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,10 +251,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            export-auth-token: "true"
+            oidc-auth-only: "false"
+          # Exercise the deprecated alias as well as the preferred input.
+          - os: macos-latest
+            export-auth-token: "false"
+            oidc-auth-only: "true"
+          - os: windows-latest
+            export-auth-token: "true"
+            oidc-auth-only: "false"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
@@ -268,7 +275,8 @@ jobs:
         uses: ./
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
-          export-auth-token: "true"
+          export-auth-token: ${{ matrix.export-auth-token }}
+          oidc-auth-only: ${{ matrix.oidc-auth-only }}
           verify-auth: "true"
 
       - name: Check exported token
@@ -279,6 +287,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$CLOUDSMITH_API_KEY" = "$EXPECTED_API_KEY"
+          test "$CLOUDSMITH_USERNAME" = "token"
           test "$OUTPUT_TOKEN" = "$EXPECTED_API_KEY"
 
       - name: whoami from PATH
@@ -294,10 +303,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            export-auth-token: "true"
+            oidc-auth-only: "false"
+          # Exercise the deprecated alias as well as the preferred input.
+          - os: macos-latest
+            export-auth-token: "false"
+            oidc-auth-only: "true"
+          - os: windows-latest
+            export-auth-token: "true"
+            oidc-auth-only: "false"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
@@ -312,7 +328,8 @@ jobs:
         with:
           oidc-namespace: ${{ vars.CLOUDSMITH_NAMESPACE }}
           oidc-service-slug: ${{ vars.CLOUDSMITH_SERVICE_SLUG }}
-          export-auth-token: "true"
+          export-auth-token: ${{ matrix.export-auth-token }}
+          oidc-auth-only: ${{ matrix.oidc-auth-only }}
           verify-auth: "true"
 
       - name: Check exported token
@@ -323,6 +340,7 @@ jobs:
           set -euo pipefail
           test -n "$OUTPUT_TOKEN"
           test "$CLOUDSMITH_API_KEY" = "$OUTPUT_TOKEN"
+          test "$CLOUDSMITH_USERNAME" = "token"
 
       - name: whoami from PATH
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Composite action** - The action is now a composite action that installs the standalone Cloudsmith CLI binary via bundled installer scripts. No Python or Node.js runtime is required.
 - **CLI-native OIDC** - The CLI performs the OIDC token exchange on its first authenticated command; the action only exports `CLOUDSMITH_ORG`, `CLOUDSMITH_SERVICE_SLUG`, and `CLOUDSMITH_OIDC_AUDIENCE`. The default audience remains `https://github.com/{repository-owner}`.
-- **Removed inputs** - `pip-install`, `oidc-auth-only`, `oidc-auth-retry`, `oidc-token-validate`, and `executable-path`. See the README migration table.
-- **Removed output** - `oidc-token`. The action never holds a Cloudsmith token.
+- **Removed inputs** - `pip-install`, `oidc-auth-retry`, `oidc-token-validate`, and `executable-path`. `oidc-auth-only` survives only as a deprecated alias for `export-api-key` and no longer skips the CLI installation. See the README migration table.
+- **Removed output** - `oidc-token`. By default the action never holds a Cloudsmith token; it is set only when `export-api-key` (or its `oidc-auth-only` alias) is enabled.
 - **No config file** - `api-host`, `api-proxy`, `api-ssl-verify`, and `api-user-agent` are exported as `CLOUDSMITH_*` environment variables instead of being written to a config file.
 
 ### Added
 
 - `install-directory` input to control where versioned CLI installations live.
 - `verify-auth` input to run `cloudsmith whoami` after setup.
+- `export-api-key` input (with `oidc-auth-only` accepted as a deprecated alias) to restore the v2 token hand-off for third-party registry clients: the action runs `cloudsmith tokens show` during setup — performing the OIDC token exchange — masks the token in workflow logs, exports it as `CLOUDSMITH_API_KEY` for later steps, and sets the `oidc-token` output. Requires Cloudsmith CLI 1.21.0 or later.
 - `cli-version`, `target`, `cli-path`, and `bin-directory` outputs.
 - Linux ARM64 (glibc and musl) and macOS ARM64 support via the standalone binaries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ### Added
 
-- `export-auth-token` exports the CLI-resolved token. `oidc-auth-only` is its deprecated alias and provides the same result through `cloudsmith tokens show` instead of raw API calls.
+- `export-auth-token` now resolves the effective credential through `cloudsmith credential-helper generic`, validates its version-1 JSON response, exports `password` as `CLOUDSMITH_API_KEY`, exports the helper's `username` as `CLOUDSMITH_USERNAME`, and preserves the masked `oidc-token` compatibility output. `oidc-auth-only` remains a deprecated alias that enables the same flow.
 
 ## [3.0.0] - 2026-07-30
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+---
+
 ## [3.1.0] - 2026-08-03
 ---
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.0] - 2026-08-03
+---
+### Added
+
+- `export-auth-token` exports the CLI-resolved token. `oidc-auth-only` is its deprecated alias and provides the same result through `cloudsmith tokens show` instead of raw API calls.
+
+## [3.0.0] - 2026-07-30
 ---
 ### Breaking Changes
 
 - **Composite action** - The action is now a composite action that installs the standalone Cloudsmith CLI binary via bundled installer scripts. No Python or Node.js runtime is required.
 - **CLI-native OIDC** - The CLI performs the OIDC token exchange on its first authenticated command; the action only exports `CLOUDSMITH_ORG`, `CLOUDSMITH_SERVICE_SLUG`, and `CLOUDSMITH_OIDC_AUDIENCE`. The default audience remains `https://github.com/{repository-owner}`.
-- **Removed inputs** - `pip-install`, `oidc-auth-retry`, `oidc-token-validate`, and `executable-path`. `oidc-auth-only` survives only as a deprecated alias for `export-api-key` and no longer skips the CLI installation. See the README migration table.
-- **Removed output** - `oidc-token`. By default the action never holds a Cloudsmith token; it is set only when `export-api-key` (or its `oidc-auth-only` alias) is enabled.
+- **Removed inputs** - `pip-install`, `oidc-auth-only`, `oidc-auth-retry`, `oidc-token-validate`, and `executable-path`. See the README migration table.
+- **Removed output** - `oidc-token`. The action never holds a Cloudsmith token.
 - **No config file** - `api-host`, `api-proxy`, `api-ssl-verify`, and `api-user-agent` are exported as `CLOUDSMITH_*` environment variables instead of being written to a config file.
 
 ### Added
 
 - `install-directory` input to control where versioned CLI installations live.
 - `verify-auth` input to run `cloudsmith whoami` after setup.
-- `export-api-key` input (with `oidc-auth-only` accepted as a deprecated alias) to restore the v2 token hand-off for third-party registry clients: the action runs `cloudsmith tokens show` during setup — performing the OIDC token exchange — masks the token in workflow logs, exports it as `CLOUDSMITH_API_KEY` for later steps, and sets the `oidc-token` output. Requires Cloudsmith CLI 1.21.0 or later.
 - `cli-version`, `target`, `cli-path`, and `bin-directory` outputs.
 - Linux ARM64 (glibc and musl) and macOS ARM64 support via the standalone binaries.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install the standalone [Cloudsmith CLI](https://github.com/cloudsmith-io/cloudsm
 | Authentication | OpenID Connect (OIDC) or API key |
 | Runners | Linux, macOS, and Windows |
 | Architectures | x86-64, plus Linux and macOS ARM64 |
-| Runtime dependencies | None; the action installs the standalone CLI binary |
+| Runtime dependencies | No Python or Node.js; `export-auth-token` additionally uses `jq` on Linux and macOS |
 | Version selection | Latest release or a specific CLI version |
 
 ## Quick start
@@ -66,7 +66,7 @@ Choose one of the following authentication methods:
 | OIDC | `oidc-namespace` and `oidc-service-slug` | The CLI exchanges a GitHub OIDC token on its first authenticated command | CI/CD workflows |
 | API key | `api-key` | The action masks and exports the key for later steps | Workflows that cannot use OIDC |
 
-With OIDC, the action exports the service account context needed by the CLI. The Cloudsmith access token is requested only when the CLI first needs to authenticate and is not exposed by default. If a later step needs the token itself — for example to configure npm, pip, or `docker login` against a Cloudsmith registry — set `export-auth-token: "true"`: the action performs the token exchange during setup via `cloudsmith tokens show`, masks the token in workflow logs, exports it as `CLOUDSMITH_API_KEY` for later steps, and sets the `oidc-token` output. This requires Cloudsmith CLI 1.21.0 or later.
+With OIDC, the action exports the service account context needed by the CLI. The Cloudsmith access token is requested only when the CLI first needs to authenticate and is not exposed by default. If a later step needs the effective credential itself — for example to configure npm, pip, or `docker login` against a Cloudsmith registry — set `export-auth-token: "true"`. The action runs `cloudsmith credential-helper generic` once, validates its versioned response, masks and exports its `password` as `CLOUDSMITH_API_KEY`, exports its package-manager username (`token`) as `CLOUDSMITH_USERNAME`, and sets the compatibility `oidc-token` output. This requires Cloudsmith CLI 1.21.0 or later. On a self-hosted Linux or macOS runner, `jq` must also be available on `PATH`.
 
 ```yaml
 - uses: cloudsmith-io/cloudsmith-cli-action@v3
@@ -108,8 +108,8 @@ An authentication method is required: provide `api-key`, or provide both `oidc-n
 | `oidc-namespace` | Cloudsmith organisation or namespace | For OIDC authentication | — |
 | `oidc-service-slug` | Cloudsmith service account slug | For OIDC authentication | — |
 | `oidc-audience` | Audience requested for the GitHub OIDC token | No | `https://github.com/{repository-owner}` |
-| `export-auth-token` | Export the resolved authentication token as `CLOUDSMITH_API_KEY` for later steps (requires CLI 1.21.0+) | No | `false` |
-| `oidc-auth-only` | Deprecated alias for `export-auth-token`; provides the same result through the CLI instead of raw API calls | No | `false` |
+| `export-auth-token` | Resolve the effective credential through `cloudsmith credential-helper generic`, export its password as `CLOUDSMITH_API_KEY`, and export its username as `CLOUDSMITH_USERNAME` (requires CLI 1.21.0+) | No | `false` |
+| `oidc-auth-only` | Deprecated alias for `export-auth-token`; when `true`, it enables the same credential-helper flow | No | `false` |
 
 ### API configuration inputs
 
@@ -128,7 +128,7 @@ An authentication method is required: provide `api-key`, or provide both `oidc-n
 | `target` | Resolved binary target, such as `linux-x86_64-gnu` |
 | `cli-path` | Absolute path to the Cloudsmith CLI executable |
 | `bin-directory` | Directory added to `PATH` for later steps |
-| `oidc-token` | Authentication token resolved by the CLI when `export-auth-token` is enabled (masked in logs) |
+| `oidc-token` | Effective authentication token resolved when `export-auth-token` or its `oidc-auth-only` alias is enabled (masked in logs; retained for compatibility) |
 
 Access an output through the action step's `id`:
 
@@ -157,7 +157,7 @@ The action configures later steps by exporting the environment variables that co
 | `api-proxy` | `CLOUDSMITH_API_PROXY` |
 | `api-user-agent` | `CLOUDSMITH_API_USER_AGENT` |
 | `api-ssl-verify` | `CLOUDSMITH_WITHOUT_API_SSL_VERIFY` |
-| `export-auth-token` | `CLOUDSMITH_API_KEY` (set to the token the CLI resolves) |
+| `export-auth-token` | `CLOUDSMITH_API_KEY` (effective credential) and `CLOUDSMITH_USERNAME` (`token`) |
 
 ## Publish a package
 
@@ -208,14 +208,14 @@ Version 3 installs the standalone CLI instead of the Python package. Existing wo
 | v2 input | Migration |
 | --- | --- |
 | `pip-install` | Remove it. Version 3 always installs the standalone binary. |
-| `oidc-auth-only` | Deprecated alias for `export-auth-token`; provides the same result through `cloudsmith tokens show` instead of raw API calls. |
+| `oidc-auth-only` | Deprecated alias for `export-auth-token`; when `true`, it enables the same `cloudsmith credential-helper generic` flow. |
 | `oidc-auth-retry` | Remove it. The CLI manages the token exchange and retries. |
 | `oidc-token-validate` | Replace it with `verify-auth: "true"`. |
 | `executable-path` | Use `install-directory` to control the installation root. Use the `cli-path` or `bin-directory` output for the resolved location. |
 
 ### `oidc-token` output
 
-By default the action no longer receives or exposes the Cloudsmith access token; authenticate subsequent requests with the CLI. Set `export-auth-token: "true"` to export it as `CLOUDSMITH_API_KEY` and restore the `oidc-token` output. Requires Cloudsmith CLI 1.21.0 or later.
+By default the action no longer receives or exposes the Cloudsmith access token; authenticate subsequent requests with the CLI. Set `export-auth-token: "true"` to resolve the effective credential through `cloudsmith credential-helper generic`, export it as `CLOUDSMITH_API_KEY`, and restore the `oidc-token` output. `oidc-auth-only: "true"` is a deprecated alias that enables the same behavior. Requires Cloudsmith CLI 1.21.0 or later.
 
 ### API configuration
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,18 @@ Choose one of the following authentication methods:
 | OIDC | `oidc-namespace` and `oidc-service-slug` | The CLI exchanges a GitHub OIDC token on its first authenticated command | CI/CD workflows |
 | API key | `api-key` | The action masks and exports the key for later steps | Workflows that cannot use OIDC |
 
-With OIDC, the action exports the service account context needed by the CLI. The Cloudsmith access token is requested only when the CLI first needs to authenticate and is not exposed as an action output.
+With OIDC, the action exports the service account context needed by the CLI. The Cloudsmith access token is requested only when the CLI first needs to authenticate and is not exposed by default. If a later step needs the token itself — for example to configure npm, pip, or `docker login` against a Cloudsmith registry — set `export-api-key: "true"`: the action performs the token exchange during setup via `cloudsmith tokens show`, masks the token in workflow logs, exports it as `CLOUDSMITH_API_KEY` for later steps, and sets the `oidc-token` output. This requires Cloudsmith CLI 1.21.0 or later.
+
+```yaml
+- uses: cloudsmith-io/cloudsmith-cli-action@v3
+  with:
+    oidc-namespace: "YOUR-NAMESPACE"
+    oidc-service-slug: "YOUR-SERVICE-ACCOUNT"
+    export-api-key: "true"
+
+- name: Authenticate npm against Cloudsmith
+  run: npm config set //npm.cloudsmith.io/YOUR-NAMESPACE/YOUR-REPOSITORY/:_authToken "$CLOUDSMITH_API_KEY"
+```
 
 ```mermaid
 flowchart LR
@@ -97,6 +108,8 @@ An authentication method is required: provide `api-key`, or provide both `oidc-n
 | `oidc-namespace` | Cloudsmith organisation or namespace | For OIDC authentication | — |
 | `oidc-service-slug` | Cloudsmith service account slug | For OIDC authentication | — |
 | `oidc-audience` | Audience requested for the GitHub OIDC token | No | `https://github.com/{repository-owner}` |
+| `export-api-key` | Export the resolved API token as `CLOUDSMITH_API_KEY` for later steps (requires CLI 1.21.0+) | No | `false` |
+| `oidc-auth-only` | Deprecated alias for `export-api-key`, kept for v2 migration | No | `false` |
 
 ### API configuration inputs
 
@@ -115,6 +128,7 @@ An authentication method is required: provide `api-key`, or provide both `oidc-n
 | `target` | Resolved binary target, such as `linux-x86_64-gnu` |
 | `cli-path` | Absolute path to the Cloudsmith CLI executable |
 | `bin-directory` | Directory added to `PATH` for later steps |
+| `oidc-token` | API token resolved by the CLI when `export-api-key` is enabled (masked in logs) |
 
 Access an output through the action step's `id`:
 
@@ -143,6 +157,7 @@ The action configures later steps by exporting the environment variables that co
 | `api-proxy` | `CLOUDSMITH_API_PROXY` |
 | `api-user-agent` | `CLOUDSMITH_API_USER_AGENT` |
 | `api-ssl-verify` | `CLOUDSMITH_WITHOUT_API_SSL_VERIFY` |
+| `export-api-key` | `CLOUDSMITH_API_KEY` (set to the token the CLI resolves) |
 
 ## Publish a package
 
@@ -193,14 +208,14 @@ Version 3 installs the standalone CLI instead of the Python package. Existing wo
 | Removed input | Migration |
 | --- | --- |
 | `pip-install` | Remove it. Version 3 always installs the standalone binary. |
-| `oidc-auth-only` | Remove it. The CLI must be installed to use this action. If only a token is needed, request one directly from the [Cloudsmith OIDC endpoint](https://docs.cloudsmith.com/authentication/openid-connect). |
+| `oidc-auth-only` | Still accepted as a deprecated alias for `export-api-key`, which masks and exports the exchanged token as `CLOUDSMITH_API_KEY` and sets the `oidc-token` output. Unlike v2, the CLI is always installed — it performs the token exchange. Rename the input to `export-api-key`. |
 | `oidc-auth-retry` | Remove it. The CLI manages the token exchange and retries. |
 | `oidc-token-validate` | Replace it with `verify-auth: "true"`. |
 | `executable-path` | Use `install-directory` to control the installation root. Use the `cli-path` or `bin-directory` output for the resolved location. |
 
-### Removed v2 output
+### `oidc-token` output
 
-The `oidc-token` output has been removed. The action no longer receives or exposes the Cloudsmith access token. Authenticate subsequent requests with the CLI, or request a token directly from the Cloudsmith OIDC endpoint.
+By default the action no longer receives or exposes the Cloudsmith access token; authenticate subsequent requests with the CLI. Workflows that consumed the v2 `oidc-token` output can set `export-api-key: "true"` (or keep the deprecated `oidc-auth-only: "true"` alias) to restore it, along with the `CLOUDSMITH_API_KEY` environment variable for later steps. Requires Cloudsmith CLI 1.21.0 or later.
 
 ### API configuration
 

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ Choose one of the following authentication methods:
 | OIDC | `oidc-namespace` and `oidc-service-slug` | The CLI exchanges a GitHub OIDC token on its first authenticated command | CI/CD workflows |
 | API key | `api-key` | The action masks and exports the key for later steps | Workflows that cannot use OIDC |
 
-With OIDC, the action exports the service account context needed by the CLI. The Cloudsmith access token is requested only when the CLI first needs to authenticate and is not exposed by default. If a later step needs the token itself — for example to configure npm, pip, or `docker login` against a Cloudsmith registry — set `export-api-key: "true"`: the action performs the token exchange during setup via `cloudsmith tokens show`, masks the token in workflow logs, exports it as `CLOUDSMITH_API_KEY` for later steps, and sets the `oidc-token` output. This requires Cloudsmith CLI 1.21.0 or later.
+With OIDC, the action exports the service account context needed by the CLI. The Cloudsmith access token is requested only when the CLI first needs to authenticate and is not exposed by default. If a later step needs the token itself — for example to configure npm, pip, or `docker login` against a Cloudsmith registry — set `export-auth-token: "true"`: the action performs the token exchange during setup via `cloudsmith tokens show`, masks the token in workflow logs, exports it as `CLOUDSMITH_API_KEY` for later steps, and sets the `oidc-token` output. This requires Cloudsmith CLI 1.21.0 or later.
 
 ```yaml
 - uses: cloudsmith-io/cloudsmith-cli-action@v3
   with:
     oidc-namespace: "YOUR-NAMESPACE"
     oidc-service-slug: "YOUR-SERVICE-ACCOUNT"
-    export-api-key: "true"
+    export-auth-token: "true"
 
 - name: Authenticate npm against Cloudsmith
   run: npm config set //npm.cloudsmith.io/YOUR-NAMESPACE/YOUR-REPOSITORY/:_authToken "$CLOUDSMITH_API_KEY"
@@ -108,8 +108,8 @@ An authentication method is required: provide `api-key`, or provide both `oidc-n
 | `oidc-namespace` | Cloudsmith organisation or namespace | For OIDC authentication | — |
 | `oidc-service-slug` | Cloudsmith service account slug | For OIDC authentication | — |
 | `oidc-audience` | Audience requested for the GitHub OIDC token | No | `https://github.com/{repository-owner}` |
-| `export-api-key` | Export the resolved API token as `CLOUDSMITH_API_KEY` for later steps (requires CLI 1.21.0+) | No | `false` |
-| `oidc-auth-only` | Deprecated alias for `export-api-key`, kept for v2 migration | No | `false` |
+| `export-auth-token` | Export the resolved authentication token as `CLOUDSMITH_API_KEY` for later steps (requires CLI 1.21.0+) | No | `false` |
+| `oidc-auth-only` | Deprecated alias for `export-auth-token`; provides the same result through the CLI instead of raw API calls | No | `false` |
 
 ### API configuration inputs
 
@@ -128,7 +128,7 @@ An authentication method is required: provide `api-key`, or provide both `oidc-n
 | `target` | Resolved binary target, such as `linux-x86_64-gnu` |
 | `cli-path` | Absolute path to the Cloudsmith CLI executable |
 | `bin-directory` | Directory added to `PATH` for later steps |
-| `oidc-token` | API token resolved by the CLI when `export-api-key` is enabled (masked in logs) |
+| `oidc-token` | Authentication token resolved by the CLI when `export-auth-token` is enabled (masked in logs) |
 
 Access an output through the action step's `id`:
 
@@ -157,7 +157,7 @@ The action configures later steps by exporting the environment variables that co
 | `api-proxy` | `CLOUDSMITH_API_PROXY` |
 | `api-user-agent` | `CLOUDSMITH_API_USER_AGENT` |
 | `api-ssl-verify` | `CLOUDSMITH_WITHOUT_API_SSL_VERIFY` |
-| `export-api-key` | `CLOUDSMITH_API_KEY` (set to the token the CLI resolves) |
+| `export-auth-token` | `CLOUDSMITH_API_KEY` (set to the token the CLI resolves) |
 
 ## Publish a package
 
@@ -203,19 +203,19 @@ Version 3 installs the standalone CLI instead of the Python package. Existing wo
 <details>
 <summary><strong>View removed inputs, outputs, and migration steps</strong></summary>
 
-### Removed v2 inputs
+### Removed and deprecated v2 inputs
 
-| Removed input | Migration |
+| v2 input | Migration |
 | --- | --- |
 | `pip-install` | Remove it. Version 3 always installs the standalone binary. |
-| `oidc-auth-only` | Still accepted as a deprecated alias for `export-api-key`, which masks and exports the exchanged token as `CLOUDSMITH_API_KEY` and sets the `oidc-token` output. Unlike v2, the CLI is always installed — it performs the token exchange. Rename the input to `export-api-key`. |
+| `oidc-auth-only` | Deprecated alias for `export-auth-token`; provides the same result through `cloudsmith tokens show` instead of raw API calls. |
 | `oidc-auth-retry` | Remove it. The CLI manages the token exchange and retries. |
 | `oidc-token-validate` | Replace it with `verify-auth: "true"`. |
 | `executable-path` | Use `install-directory` to control the installation root. Use the `cli-path` or `bin-directory` output for the resolved location. |
 
 ### `oidc-token` output
 
-By default the action no longer receives or exposes the Cloudsmith access token; authenticate subsequent requests with the CLI. Workflows that consumed the v2 `oidc-token` output can set `export-api-key: "true"` (or keep the deprecated `oidc-auth-only: "true"` alias) to restore it, along with the `CLOUDSMITH_API_KEY` environment variable for later steps. Requires Cloudsmith CLI 1.21.0 or later.
+By default the action no longer receives or exposes the Cloudsmith access token; authenticate subsequent requests with the CLI. Set `export-auth-token: "true"` to export it as `CLOUDSMITH_API_KEY` and restore the `oidc-token` output. Requires Cloudsmith CLI 1.21.0 or later.
 
 ### API configuration
 

--- a/action.yml
+++ b/action.yml
@@ -52,11 +52,11 @@ inputs:
     required: false
     default: "false"
   export-auth-token:
-    description: "Export the authentication token resolved by the CLI as CLOUDSMITH_API_KEY for later steps. Requires Cloudsmith CLI 1.21.0 or later."
+    description: "Resolve credentials with 'cloudsmith credential-helper generic', then export its password as CLOUDSMITH_API_KEY and username as CLOUDSMITH_USERNAME. Requires Cloudsmith CLI 1.21.0 or later."
     required: false
     default: "false"
   oidc-auth-only:
-    description: "Deprecated alias for export-auth-token, which provides the same result through the CLI instead of raw API calls."
+    description: "Deprecated alias for export-auth-token. When true, it enables the same CLI credential-helper flow."
     required: false
     default: "false"
 
@@ -74,7 +74,7 @@ outputs:
     description: "Directory added to PATH for subsequent steps."
     value: ${{ steps.setup-posix.outputs.bin-directory || steps.setup-windows.outputs.bin-directory }}
   oidc-token:
-    description: "Authentication token resolved by the CLI when export-auth-token is enabled. Masked in workflow logs."
+    description: "Effective authentication token resolved by the CLI when export-auth-token or its oidc-auth-only alias is enabled. Masked in workflow logs."
     value: ${{ steps.setup-posix.outputs.oidc-token || steps.setup-windows.outputs.oidc-token }}
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -51,12 +51,12 @@ inputs:
     description: "Run 'cloudsmith whoami' after setup to verify authentication."
     required: false
     default: "false"
-  export-api-key:
-    description: "Export the API token the CLI resolves as CLOUDSMITH_API_KEY for later steps, performing the OIDC token exchange during setup. Requires Cloudsmith CLI 1.21.0 or later."
+  export-auth-token:
+    description: "Export the authentication token resolved by the CLI as CLOUDSMITH_API_KEY for later steps. Requires Cloudsmith CLI 1.21.0 or later."
     required: false
     default: "false"
   oidc-auth-only:
-    description: "Deprecated alias for export-api-key, kept for v2 migration. Version 3 always installs the CLI."
+    description: "Deprecated alias for export-auth-token, which provides the same result through the CLI instead of raw API calls."
     required: false
     default: "false"
 
@@ -74,7 +74,7 @@ outputs:
     description: "Directory added to PATH for subsequent steps."
     value: ${{ steps.setup-posix.outputs.bin-directory || steps.setup-windows.outputs.bin-directory }}
   oidc-token:
-    description: "API token resolved by the CLI when export-api-key is enabled. Masked in workflow logs."
+    description: "Authentication token resolved by the CLI when export-auth-token is enabled. Masked in workflow logs."
     value: ${{ steps.setup-posix.outputs.oidc-token || steps.setup-windows.outputs.oidc-token }}
 
 runs:
@@ -96,7 +96,7 @@ runs:
         INPUT_API_SSL_VERIFY: ${{ inputs.api-ssl-verify }}
         INPUT_API_USER_AGENT: ${{ inputs.api-user-agent }}
         INPUT_VERIFY_AUTH: ${{ inputs.verify-auth }}
-        INPUT_EXPORT_API_KEY: ${{ inputs.export-api-key }}
+        INPUT_EXPORT_AUTH_TOKEN: ${{ inputs.export-auth-token }}
         INPUT_OIDC_AUTH_ONLY: ${{ inputs.oidc-auth-only }}
       run: bash "$GITHUB_ACTION_PATH/scripts/setup.sh"
 
@@ -116,6 +116,6 @@ runs:
         INPUT_API_SSL_VERIFY: ${{ inputs.api-ssl-verify }}
         INPUT_API_USER_AGENT: ${{ inputs.api-user-agent }}
         INPUT_VERIFY_AUTH: ${{ inputs.verify-auth }}
-        INPUT_EXPORT_API_KEY: ${{ inputs.export-api-key }}
+        INPUT_EXPORT_AUTH_TOKEN: ${{ inputs.export-auth-token }}
         INPUT_OIDC_AUTH_ONLY: ${{ inputs.oidc-auth-only }}
       run: '& "$env:GITHUB_ACTION_PATH\scripts\setup.ps1"'

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,14 @@ inputs:
     description: "Run 'cloudsmith whoami' after setup to verify authentication."
     required: false
     default: "false"
+  export-api-key:
+    description: "Export the API token the CLI resolves as CLOUDSMITH_API_KEY for later steps, performing the OIDC token exchange during setup. Requires Cloudsmith CLI 1.21.0 or later."
+    required: false
+    default: "false"
+  oidc-auth-only:
+    description: "Deprecated alias for export-api-key, kept for v2 migration. Version 3 always installs the CLI."
+    required: false
+    default: "false"
 
 outputs:
   cli-version:
@@ -65,6 +73,9 @@ outputs:
   bin-directory:
     description: "Directory added to PATH for subsequent steps."
     value: ${{ steps.setup-posix.outputs.bin-directory || steps.setup-windows.outputs.bin-directory }}
+  oidc-token:
+    description: "API token resolved by the CLI when export-api-key is enabled. Masked in workflow logs."
+    value: ${{ steps.setup-posix.outputs.oidc-token || steps.setup-windows.outputs.oidc-token }}
 
 runs:
   using: "composite"
@@ -85,6 +96,8 @@ runs:
         INPUT_API_SSL_VERIFY: ${{ inputs.api-ssl-verify }}
         INPUT_API_USER_AGENT: ${{ inputs.api-user-agent }}
         INPUT_VERIFY_AUTH: ${{ inputs.verify-auth }}
+        INPUT_EXPORT_API_KEY: ${{ inputs.export-api-key }}
+        INPUT_OIDC_AUTH_ONLY: ${{ inputs.oidc-auth-only }}
       run: bash "$GITHUB_ACTION_PATH/scripts/setup.sh"
 
     - name: Install and configure Cloudsmith CLI
@@ -103,4 +116,6 @@ runs:
         INPUT_API_SSL_VERIFY: ${{ inputs.api-ssl-verify }}
         INPUT_API_USER_AGENT: ${{ inputs.api-user-agent }}
         INPUT_VERIFY_AUTH: ${{ inputs.verify-auth }}
+        INPUT_EXPORT_API_KEY: ${{ inputs.export-api-key }}
+        INPUT_OIDC_AUTH_ONLY: ${{ inputs.oidc-auth-only }}
       run: '& "$env:GITHUB_ACTION_PATH\scripts\setup.ps1"'

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -49,6 +49,20 @@ if ($verifyAuth -notin @('true', 'false')) {
   throw "verify-auth must be true or false"
 }
 
+$exportApiKey = ([string]$env:INPUT_EXPORT_API_KEY).ToLowerInvariant()
+if ($exportApiKey -notin @('true', 'false')) {
+  throw "export-api-key must be true or false"
+}
+
+$oidcAuthOnly = ([string]$env:INPUT_OIDC_AUTH_ONLY).ToLowerInvariant()
+if ($oidcAuthOnly -notin @('true', 'false')) {
+  throw "oidc-auth-only must be true or false"
+}
+if ($oidcAuthOnly -eq 'true') {
+  Write-Host "::warning::The 'oidc-auth-only' input is a deprecated alias for 'export-api-key'. Version 3 always installs the CLI before exporting the token."
+  $exportApiKey = 'true'
+}
+
 $cliVersion = $env:INPUT_CLI_VERSION
 if ([string]::IsNullOrWhiteSpace($cliVersion)) {
   $cliVersion = "latest"
@@ -146,6 +160,18 @@ switch ($apiSslVerify) {
   'false' { Write-JobEnvironment -Name CLOUDSMITH_WITHOUT_API_SSL_VERIFY -Value 'true' }
 }
 
+$exportedToken = ''
+if ($exportApiKey -eq 'true') {
+  # 'tokens show' prints only the resolved token on stdout, performing the
+  # OIDC token exchange when that is the resolving credential source.
+  $exportedToken = (& $executable tokens show | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($exportedToken)) {
+    throw "Failed to read the API token. 'export-api-key' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
+  }
+  Write-Host "::add-mask::$exportedToken"
+  Write-JobEnvironment -Name CLOUDSMITH_API_KEY -Value $exportedToken
+}
+
 if ($verifyAuth -eq 'true') {
   # whoami prints its status to stdout. Some CLI builds exit 0 even on a 401,
   # so treat the failure marker in the output as authoritative too.
@@ -162,5 +188,8 @@ Add-GitHubLine -Path $env:GITHUB_OUTPUT -Line "cli-version=$resolvedVersion"
 Add-GitHubLine -Path $env:GITHUB_OUTPUT -Line "target=$target"
 Add-GitHubLine -Path $env:GITHUB_OUTPUT -Line "cli-path=$executable"
 Add-GitHubLine -Path $env:GITHUB_OUTPUT -Line "bin-directory=$binDirectory"
+if (-not [string]::IsNullOrEmpty($exportedToken)) {
+  Add-GitHubLine -Path $env:GITHUB_OUTPUT -Line "oidc-token=$exportedToken"
+}
 
 Write-Host "Cloudsmith CLI $resolvedVersion is available at $executable"

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -49,9 +49,9 @@ if ($verifyAuth -notin @('true', 'false')) {
   throw "verify-auth must be true or false"
 }
 
-$exportApiKey = ([string]$env:INPUT_EXPORT_API_KEY).ToLowerInvariant()
-if ($exportApiKey -notin @('true', 'false')) {
-  throw "export-api-key must be true or false"
+$exportAuthToken = ([string]$env:INPUT_EXPORT_AUTH_TOKEN).ToLowerInvariant()
+if ($exportAuthToken -notin @('true', 'false')) {
+  throw "export-auth-token must be true or false"
 }
 
 $oidcAuthOnly = ([string]$env:INPUT_OIDC_AUTH_ONLY).ToLowerInvariant()
@@ -59,8 +59,8 @@ if ($oidcAuthOnly -notin @('true', 'false')) {
   throw "oidc-auth-only must be true or false"
 }
 if ($oidcAuthOnly -eq 'true') {
-  Write-Host "::warning::The 'oidc-auth-only' input is a deprecated alias for 'export-api-key'. Version 3 always installs the CLI before exporting the token."
-  $exportApiKey = 'true'
+  Write-Host "::warning::The 'oidc-auth-only' input is deprecated and aliases 'export-auth-token', which provides the same result through the CLI instead of raw API calls."
+  $exportAuthToken = 'true'
 }
 
 $cliVersion = $env:INPUT_CLI_VERSION
@@ -161,12 +161,12 @@ switch ($apiSslVerify) {
 }
 
 $exportedToken = ''
-if ($exportApiKey -eq 'true') {
+if ($exportAuthToken -eq 'true') {
   # 'tokens show' prints only the resolved token on stdout, performing the
   # OIDC token exchange when that is the resolving credential source.
   $exportedToken = (& $executable tokens show | Out-String).Trim()
   if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($exportedToken)) {
-    throw "Failed to read the API token. 'export-api-key' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
+    throw "Failed to read the authentication token. 'export-auth-token' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
   }
   Write-Host "::add-mask::$exportedToken"
   Write-JobEnvironment -Name CLOUDSMITH_API_KEY -Value $exportedToken

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -59,7 +59,7 @@ if ($oidcAuthOnly -notin @('true', 'false')) {
   throw "oidc-auth-only must be true or false"
 }
 if ($oidcAuthOnly -eq 'true') {
-  Write-Host "::warning::The 'oidc-auth-only' input is deprecated and aliases 'export-auth-token', which provides the same result through the CLI instead of raw API calls."
+  Write-Host "::warning::The 'oidc-auth-only' input is deprecated; use 'export-auth-token'. Both resolve credentials through 'cloudsmith credential-helper generic'."
   $exportAuthToken = 'true'
 }
 
@@ -161,18 +161,52 @@ switch ($apiSslVerify) {
 }
 
 $exportedToken = ''
+$credentialUsername = ''
 if ($exportAuthToken -eq 'true') {
-  # 'tokens show' prints only the resolved token on stdout, performing the
-  # OIDC token exchange when that is the resolving credential source.
-  $exportedToken = (& $executable tokens show | Out-String).Trim()
-  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($exportedToken)) {
-    throw "Failed to read the authentication token. 'export-auth-token' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
+  # Resolve once: the helper performs the OIDC exchange when OIDC is the
+  # effective source and emits a versioned JSON credential document.
+  $credentialJsonLines = & $executable credential-helper generic
+  $credentialStatus = $LASTEXITCODE
+  if ($credentialStatus -ne 0) {
+    throw "Failed to resolve credentials. 'export-auth-token' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
   }
+  $credentialJson = ($credentialJsonLines | Out-String).Trim()
+  if ([string]::IsNullOrEmpty($credentialJson)) {
+    throw "The CLI returned an empty credential-helper response."
+  }
+
+  try {
+    $credential = $credentialJson | ConvertFrom-Json -ErrorAction Stop
+  }
+  catch {
+    throw "The CLI returned an invalid credential-helper response."
+  }
+
+  $properties = @($credential.PSObject.Properties.Name)
+  $hasExpectedProperties = (
+    $properties.Count -eq 3 -and
+    $properties -contains 'version' -and
+    $properties -contains 'username' -and
+    $properties -contains 'password'
+  )
+  if (
+    -not $hasExpectedProperties -or
+    $credential.version -ne 1 -or
+    $credential.username -ne 'token' -or
+    $credential.password -isnot [string] -or
+    [string]::IsNullOrEmpty($credential.password)
+  ) {
+    throw "The CLI returned an invalid or unsupported credential-helper response."
+  }
+
+  $credentialUsername = [string]$credential.username
+  $exportedToken = [string]$credential.password
   if ($exportedToken.Contains("`n") -or $exportedToken.Contains("`r")) {
     throw "The CLI returned a token containing a newline"
   }
   Write-Host "::add-mask::$exportedToken"
   Write-JobEnvironment -Name CLOUDSMITH_API_KEY -Value $exportedToken
+  Write-JobEnvironment -Name CLOUDSMITH_USERNAME -Value $credentialUsername
 }
 
 if ($verifyAuth -eq 'true') {

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -168,6 +168,9 @@ if ($exportAuthToken -eq 'true') {
   if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrEmpty($exportedToken)) {
     throw "Failed to read the authentication token. 'export-auth-token' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
   }
+  if ($exportedToken.Contains("`n") -or $exportedToken.Contains("`r")) {
+    throw "The CLI returned a token containing a newline"
+  }
   Write-Host "::add-mask::$exportedToken"
   Write-JobEnvironment -Name CLOUDSMITH_API_KEY -Value $exportedToken
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,10 +61,10 @@ case "$verify_auth" in
   *) fail "verify-auth must be true or false" ;;
 esac
 
-export_api_key="$(printf '%s' "$INPUT_EXPORT_API_KEY" | tr '[:upper:]' '[:lower:]')"
-case "$export_api_key" in
+export_auth_token="$(printf '%s' "$INPUT_EXPORT_AUTH_TOKEN" | tr '[:upper:]' '[:lower:]')"
+case "$export_auth_token" in
   true|false) ;;
-  *) fail "export-api-key must be true or false" ;;
+  *) fail "export-auth-token must be true or false" ;;
 esac
 
 oidc_auth_only="$(printf '%s' "$INPUT_OIDC_AUTH_ONLY" | tr '[:upper:]' '[:lower:]')"
@@ -73,8 +73,8 @@ case "$oidc_auth_only" in
   *) fail "oidc-auth-only must be true or false" ;;
 esac
 if [[ "$oidc_auth_only" == "true" ]]; then
-  echo "::warning::The 'oidc-auth-only' input is a deprecated alias for 'export-api-key'. Version 3 always installs the CLI before exporting the token."
-  export_api_key="true"
+  echo "::warning::The 'oidc-auth-only' input is deprecated and aliases 'export-auth-token', which provides the same result through the CLI instead of raw API calls."
+  export_auth_token="true"
 fi
 
 cli_version="$INPUT_CLI_VERSION"
@@ -149,11 +149,11 @@ case "$api_ssl_verify" in
 esac
 
 exported_token=""
-if [[ "$export_api_key" == "true" ]]; then
+if [[ "$export_auth_token" == "true" ]]; then
   # 'tokens show' prints only the resolved token on stdout, performing the
   # OIDC token exchange when that is the resolving credential source.
   if ! exported_token="$("$executable" tokens show)"; then
-    fail "Failed to read the API token. 'export-api-key' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
+    fail "Failed to read the authentication token. 'export-auth-token' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
   fi
   [[ -n "$exported_token" ]] \
     || fail "The CLI returned an empty token"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -73,7 +73,7 @@ case "$oidc_auth_only" in
   *) fail "oidc-auth-only must be true or false" ;;
 esac
 if [[ "$oidc_auth_only" == "true" ]]; then
-  echo "::warning::The 'oidc-auth-only' input is deprecated and aliases 'export-auth-token', which provides the same result through the CLI instead of raw API calls."
+  echo "::warning::The 'oidc-auth-only' input is deprecated; use 'export-auth-token'. Both resolve credentials through 'cloudsmith credential-helper generic'."
   export_auth_token="true"
 fi
 
@@ -149,18 +149,46 @@ case "$api_ssl_verify" in
 esac
 
 exported_token=""
+credential_username=""
 if [[ "$export_auth_token" == "true" ]]; then
-  # 'tokens show' prints only the resolved token on stdout, performing the
-  # OIDC token exchange when that is the resolving credential source.
-  if ! exported_token="$("$executable" tokens show)"; then
-    fail "Failed to read the authentication token. 'export-auth-token' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
+  command -v jq >/dev/null 2>&1 \
+    || fail "The 'export-auth-token' input requires jq on Linux and macOS runners."
+
+  # Resolve once: the helper performs the OIDC exchange when OIDC is the
+  # effective source and emits a versioned JSON credential document.
+  if ! credential_document="$("$executable" credential-helper generic)"; then
+    fail "Failed to resolve credentials. 'export-auth-token' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
   fi
+
+  # Validate the protocol before extracting the password. Never assign the
+  # raw JSON document to CLOUDSMITH_API_KEY.
+  if ! credential_values="$(
+    printf '%s' "$credential_document" | jq -er '
+      if type == "object"
+        and (keys == ["password", "username", "version"])
+        and (.version == 1)
+        and (.username == "token")
+        and (.password | type == "string" and length > 0)
+        and (.password | test("[\\r\\n]") | not)
+      then .username, .password
+      else error("unsupported credential-helper response")
+      end
+    '
+  )"; then
+    fail "The CLI returned an invalid or unsupported credential-helper response."
+  fi
+  [[ "$credential_values" == *$'\n'* ]] \
+    || fail "The CLI returned an incomplete credential-helper response."
+  credential_username="${credential_values%%$'\n'*}"
+  exported_token="${credential_values#*$'\n'}"
+
   [[ -n "$exported_token" ]] \
     || fail "The CLI returned an empty token"
   [[ "$exported_token" != *$'\n'* && "$exported_token" != *$'\r'* ]] \
     || fail "The CLI returned a token containing a newline"
   echo "::add-mask::$exported_token"
   append_env CLOUDSMITH_API_KEY "$exported_token"
+  append_env CLOUDSMITH_USERNAME "$credential_username"
 fi
 
 if [[ "$verify_auth" == "true" ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -157,6 +157,8 @@ if [[ "$export_auth_token" == "true" ]]; then
   fi
   [[ -n "$exported_token" ]] \
     || fail "The CLI returned an empty token"
+  [[ "$exported_token" != *$'\n'* && "$exported_token" != *$'\r'* ]] \
+    || fail "The CLI returned a token containing a newline"
   echo "::add-mask::$exported_token"
   append_env CLOUDSMITH_API_KEY "$exported_token"
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,6 +61,22 @@ case "$verify_auth" in
   *) fail "verify-auth must be true or false" ;;
 esac
 
+export_api_key="$(printf '%s' "$INPUT_EXPORT_API_KEY" | tr '[:upper:]' '[:lower:]')"
+case "$export_api_key" in
+  true|false) ;;
+  *) fail "export-api-key must be true or false" ;;
+esac
+
+oidc_auth_only="$(printf '%s' "$INPUT_OIDC_AUTH_ONLY" | tr '[:upper:]' '[:lower:]')"
+case "$oidc_auth_only" in
+  true|false) ;;
+  *) fail "oidc-auth-only must be true or false" ;;
+esac
+if [[ "$oidc_auth_only" == "true" ]]; then
+  echo "::warning::The 'oidc-auth-only' input is a deprecated alias for 'export-api-key'. Version 3 always installs the CLI before exporting the token."
+  export_api_key="true"
+fi
+
 cli_version="$INPUT_CLI_VERSION"
 if [[ -z "$cli_version" ]]; then
   cli_version="latest"
@@ -132,6 +148,19 @@ case "$api_ssl_verify" in
   false) append_env CLOUDSMITH_WITHOUT_API_SSL_VERIFY "true" ;;
 esac
 
+exported_token=""
+if [[ "$export_api_key" == "true" ]]; then
+  # 'tokens show' prints only the resolved token on stdout, performing the
+  # OIDC token exchange when that is the resolving credential source.
+  if ! exported_token="$("$executable" tokens show)"; then
+    fail "Failed to read the API token. 'export-api-key' requires Cloudsmith CLI 1.21.0 or later and valid credentials."
+  fi
+  [[ -n "$exported_token" ]] \
+    || fail "The CLI returned an empty token"
+  echo "::add-mask::$exported_token"
+  append_env CLOUDSMITH_API_KEY "$exported_token"
+fi
+
 if [[ "$verify_auth" == "true" ]]; then
   # whoami prints its status to stdout. Some CLI builds exit 0 even on a 401,
   # so treat the failure marker in the output as authoritative too.
@@ -153,5 +182,7 @@ fi
   printf 'cli-path=%s\n' "$executable"
   printf 'bin-directory=%s\n' "$bin_dir"
 } >> "$GITHUB_OUTPUT"
+[[ -z "$exported_token" ]] \
+  || printf 'oidc-token=%s\n' "$exported_token" >> "$GITHUB_OUTPUT"
 
 echo "Cloudsmith CLI $resolved_version is available at $executable"


### PR DESCRIPTION
# Description

Adds an opt-in `export-auth-token` input that resolves the effective Cloudsmith credential through `cloudsmith credential-helper generic`.

The action invokes the helper once, validates its version-1 JSON response, masks the credential, and exports:

- `.password` as `CLOUDSMITH_API_KEY`;
- `.username` as `CLOUDSMITH_USERNAME` (the package-client value `token`); and
- `.password` through the existing `oidc-token` output for compatibility.

The deprecated `oidc-auth-only` input is retained as an alias for `export-auth-token`. When it is set to `true`, it enables the same credential-export flow and emits a deprecation warning. The default lazy OIDC behavior remains unchanged when neither input is enabled.

This allows later workflow steps and third-party package clients to reuse the CLI-resolved credential without parsing the helper response themselves.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Additional Notes

- Requires Cloudsmith CLI 1.21.0 or later when credential export is enabled.
- Linux and macOS runners require `jq` when credential export is enabled. GitHub-hosted runners already provide it; self-hosted runners must make it available on `PATH`.
- The password is masked before it is written to the job environment or action output.
- Invalid, unsupported, empty, or multiline credential-helper responses fail the setup step.
- API-key authentication remains supported and unchanged.

## Validation

Static validation passed:

- Bash syntax and ShellCheck
- PowerShell AST parsing and PSScriptAnalyzer
- actionlint
- `git diff --check`

A live private-repository workflow tested this PR's head commit with Cloudsmith CLI v1.21.0:

- unchanged lazy OIDC behavior on Ubuntu;
- `export-auth-token: "true"` on Ubuntu and macOS;
- deprecated `oidc-auth-only: "true"` on Ubuntu and Windows; and
- the existing `api-key` input on Ubuntu.

All six jobs passed. The tests verified successful authentication, exact CLI version, matching `CLOUDSMITH_API_KEY`/`CLOUDSMITH_USERNAME`/output values, the expected deprecation warning, and that no raw credential JSON or unmasked token appeared in the logs.

Test run: https://github.com/BartoszBlizniak/github-actions-demo/actions/runs/30825267945
